### PR TITLE
patch: 'Hide created by' if creatorName includes Created

### DIFF
--- a/components/MintNengajo/index.tsx
+++ b/components/MintNengajo/index.tsx
@@ -107,7 +107,9 @@ const MintNengajo: React.FC<Props> = ({ id, item, imageOnly, ...props }) => {
           )}
           {creatorName && (
             <Text textAlign="right" fontSize="sm" mt={1}>
-              created by {creatorName}
+              {creatorName.includes('Created')
+                ? creatorName
+                : `created by ${creatorName}`}
             </Text>
           )}
           <Text mt={5}>{item?.tokenURIJSON?.description}</Text>


### PR DESCRIPTION
# problem

It has redundantly "created by"
<img width="506" alt="image" src="https://user-images.githubusercontent.com/4782857/209758648-4549a143-1ce4-40d7-8164-b081a03ec171.png">

# solution

- add patch to hide created by if creatorName includes created

# UI
before | After |
------- | ---- |
<img width="506" alt="image" src="https://user-images.githubusercontent.com/4782857/209758648-4549a143-1ce4-40d7-8164-b081a03ec171.png">| <img width="487" alt="image" src="https://user-images.githubusercontent.com/4782857/209758936-00a70bda-f9a3-41f1-a8d3-94813c89bc24.png">

