### PR TITLE
fix: OmamoriesList-images

### DIFF
--- a/components/OmamoriesList/index.tsx
+++ b/components/OmamoriesList/index.tsx
@@ -50,7 +50,7 @@ const OmamoriesList: React.FC<OmamoriesListProps> = ({ items }) => {
       {allOmamoriesInfo.map((omamoriInfo, index) => {
         if (!omamoriInfo.tokenURIJSON) return
         const minted = mintedOmamories?.some(
-          (mintedOmamori) => mintedOmamori.id === omamoriInfo.id
+          (mintedOmamori) => Number(mintedOmamori.id) === Number(omamoriInfo.id)
         )
         return (
           <div key={index} className={styles.list}>


### PR DESCRIPTION
OmamoriesList内の御守りの画像を修正しました！

ミント済みの場合でも、一覧ページで内府の画像が表示されてしまう問題を修正